### PR TITLE
Issue #3135088: Replace API key input with key module

### DIFF
--- a/loqate.info.yml
+++ b/loqate.info.yml
@@ -4,3 +4,6 @@ description: 'Provides an integration with Loqate address lookup API.'
 core: 8.x
 core_version_requirement: ^8 || ^9
 package: 'Address'
+configure: loqate.loqate_api_key_config_form
+dependencies:
+  - key:key

--- a/loqate.install
+++ b/loqate.install
@@ -5,6 +5,9 @@
  * Contains loqate.install.
  */
 
+use Drupal\key\Entity\Key;
+use Drupal\loqate\Form\LoqateApiKeyConfigForm;
+
 /**
  * Decoupled Webform so install pca_webform submodule for the moved plugins.
  */
@@ -12,4 +15,39 @@ function loqate_update_8001() {
   // All sites using this module up until now would have had these plugins.
   \Drupal::service('module_installer')->install(['pca_webform']);
   return t('PCA Webform installed.');
+}
+
+/**
+ * Install new dependency on the key module.
+ */
+function loqate_update_8002() {
+  // All sites using this module up until now will need this update.
+  \Drupal::service('module_installer')->install(['key']);
+  return t('Key installed.');
+}
+
+/**
+ * Convert old key string value into a key config entity.
+ */
+function loqate_update_8003() {
+  // Move the string value into a key config entity if any.
+  $loqate_config = \Drupal::configFactory()->getEditable('loqate.loqateapikeyconfig');
+  $old_key_value = $loqate_config->get(LoqateApiKeyConfigForm::DEFAULT_API_KEY);
+  if (!empty($old_key_value)) {
+    // Create a new entity key with the config key provider.
+    $key_entity = new Key([
+      'id' => LoqateApiKeyConfigForm::DEFAULT_API_KEY,
+      'label' => 'Loqate API key',
+      'key_provider' => 'config',
+      'key_input' => 'text_field',
+    ], 'key');
+    $key_entity->setKeyValue($old_key_value);
+    $key_entity->save();
+    // Set the config id now as the key value in config.
+    $loqate_config
+      ->set(LoqateApiKeyConfigForm::DEFAULT_API_KEY, LoqateApiKeyConfigForm::DEFAULT_API_KEY)
+      ->save();
+    return t('Key config entity successfully created.');
+  }
+  return t('No old key value found.');
 }

--- a/modules/pca_address/src/Element/PcaAddress.php
+++ b/modules/pca_address/src/Element/PcaAddress.php
@@ -8,7 +8,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Url;
-use Drupal\loqate\Form\LoqateApiKeyConfigForm;
+use Drupal\loqate\Loqate;
 use Drupal\loqate\PcaAddressFieldMapping\PcaAddressElement;
 use Drupal\pca_address\Form\PcaAddressSettingsForm;
 
@@ -213,12 +213,12 @@ class PcaAddress extends Address {
    */
   private static function preparePcaOptions(array &$element): void {
     $element['#attached']['drupalSettings']['pca_address']['elements']['#' . $element['#id']]['options'] = [
-      'key' => self::getApiKey(),
+      'key' => Loqate::getApiKey(),
     ];
     // Merge options if provided.
     if (isset($element['#pca_options'])) {
       // Before we merge the options, check on a possibly provided API key value.
-      if (isset($element['#pca_options']['key']) && $key = self::getApiKey($element['#pca_options']['key'])) {
+      if (isset($element['#pca_options']['key']) && $key = Loqate::getApiKey($element['#pca_options']['key'])) {
         // Replace the config key id with the key value.
         $element['#pca_options']['key'] = $key;
       }
@@ -230,27 +230,6 @@ class PcaAddress extends Address {
         $element['#attached']['drupalSettings']['pca_address']['elements']['#' . $element['#id']]['options'], $element['#pca_options']
       );
     }
-  }
-
-  /**
-   * Gets the Loqate API key value.
-   *
-   * @param string $config_key
-   *   Optional custom config key.
-   * @return string|null
-   *   The key value if found or NULL.
-   */
-  private static function getApiKey($config_key = LoqateApiKeyConfigForm::DEFAULT_API_KEY) {
-    $key_id = \Drupal::config('loqate.loqateapikeyconfig')->get($config_key);
-    if ($key_id) {
-      /** @var \Drupal\key\KeyRepositoryInterface $key_repository */
-      $key_repository = \Drupal::service('key.repository');
-      $key_entity = $key_repository->getKey($key_id);
-      if ($key_entity) {
-        return $key_entity->getKeyValue();
-      }
-    }
-    return NULL;
   }
 
 }

--- a/modules/pca_address/src/Plugin/Field/FieldWidget/PcaAddressWidget.php
+++ b/modules/pca_address/src/Plugin/Field/FieldWidget/PcaAddressWidget.php
@@ -30,6 +30,7 @@ class PcaAddressWidget extends AddressDefaultWidget {
       'pca_options' => [],
       'show_address_fields' => FALSE,
       'allow_manual_input' => TRUE,
+      'loqate_api_key' => NULL,
     ] + parent::defaultSettings();
   }
 
@@ -49,6 +50,12 @@ class PcaAddressWidget extends AddressDefaultWidget {
       '#type' => 'checkbox',
       '#title' => $this->t('Allow manual input'),
       '#default_value' => $this->getSetting('allow_manual_input'),
+    ];
+
+    $form['loqate_api_key'] = [
+      '#type' => 'key_select',
+      '#title' => $this->t('Loqate API key'),
+      '#default_value' => $this->getSetting('loqate_api_key'),
     ];
 
     return $form;
@@ -87,10 +94,14 @@ class PcaAddressWidget extends AddressDefaultWidget {
     $element['address']['#pca_fields'] = $widget_settings['pca_fields'];
     // Set options settings.
     $element['address']['#pca_options'] = $widget_settings['pca_options'];
-    // Set options settings.
+    // Set show address fields bool.
     $element['address']['#show_address_fields'] = (bool) $widget_settings['show_address_fields'];
-    // Set options settings.
+    // Set allow manual input bool.
     $element['address']['#allow_manual_input'] = (bool) $widget_settings['allow_manual_input'];
+    // Set options key if set.
+    if ($widget_settings['loqate_api_key']) {
+      $element['address']['#pca_options']['key'] = $widget_settings['loqate_api_key'];
+    }
     return $element;
   }
 

--- a/modules/pca_webform/src/Element/WebformAddressLoqate.php
+++ b/modules/pca_webform/src/Element/WebformAddressLoqate.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\pca_webform\Element;
 
+use Drupal\loqate\Loqate;
 use Drupal\webform\Element\WebformCompositeBase;
 
 /**
@@ -46,7 +47,7 @@ class WebformAddressLoqate extends WebformCompositeBase {
       'drupalSettings' => [
         'loqate' => [
           'loqate' => [
-            'key' => \Drupal::config('loqate.loqateapikeyconfig')->get('loqate_api_key'),
+            'key' => Loqate::getApiKey(),
           ],
         ],
       ],

--- a/src/Form/LoqateApiKeyConfigForm.php
+++ b/src/Form/LoqateApiKeyConfigForm.php
@@ -13,6 +13,11 @@ use Drupal\Core\Url;
 class LoqateApiKeyConfigForm extends ConfigFormBase {
 
   /**
+   * Config key for the default API key.
+   */
+  public const DEFAULT_API_KEY = 'loqate_api_key';
+
+  /**
    * {@inheritdoc}
    */
   protected function getEditableConfigNames() {
@@ -35,15 +40,13 @@ class LoqateApiKeyConfigForm extends ConfigFormBase {
     $config = $this->config('loqate.loqateapikeyconfig');
 
     $read_more_url = Url::fromUri('https://www.loqate.com/resources/support/setup-guides/advanced-setup-guide/#creating_a_key');
-    $description_read_more_link = Link::fromTextAndUrl('Read more about Loqate API.', $read_more_url);
+    $description_read_more_link = Link::fromTextAndUrl('Read more about Loqate API.', $read_more_url)->toString();
 
-    $form['loqate_api_key'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Loqate API key'),
+    $form[self::DEFAULT_API_KEY] = [
+      '#type' => 'key_select',
+      '#title' => $this->t('Default Loqate API key'),
       '#description' => $description_read_more_link,
-      '#maxlength' => 64,
-      '#size' => 64,
-      '#default_value' => $config->get('loqate_api_key'),
+      '#default_value' => $config->get(self::DEFAULT_API_KEY),
     ];
     return parent::buildForm($form, $form_state);
   }
@@ -55,7 +58,7 @@ class LoqateApiKeyConfigForm extends ConfigFormBase {
     parent::submitForm($form, $form_state);
 
     $this->config('loqate.loqateapikeyconfig')
-      ->set('loqate_api_key', $form_state->getValue('loqate_api_key'))
+      ->set(self::DEFAULT_API_KEY, $form_state->getValue(self::DEFAULT_API_KEY))
       ->save();
   }
 

--- a/src/Loqate.php
+++ b/src/Loqate.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\loqate;
+
+use Drupal\loqate\Form\LoqateApiKeyConfigForm;
+
+/**
+ * Class Loqate.
+ *
+ * @package Drupal\loqate
+ */
+final class Loqate {
+
+  /**
+   * Gets the Loqate API key value.
+   *
+   * @param string $config_key
+   *   Optional custom config key.
+   * @return string|null
+   *   The key value if found or NULL.
+   */
+  public static function getApiKey($config_key = LoqateApiKeyConfigForm::DEFAULT_API_KEY) {
+    $key_id = \Drupal::config('loqate.loqateapikeyconfig')->get($config_key);
+    if ($key_id) {
+      /** @var \Drupal\key\KeyRepositoryInterface $key_repository */
+      $key_repository = \Drupal::service('key.repository');
+      $key_entity = $key_repository->getKey($key_id);
+      if ($key_entity) {
+        return $key_entity->getKeyValue();
+      }
+    }
+    return NULL;
+  }
+
+}


### PR DESCRIPTION
WIP for API key input via the key module below. Still needs the following:
- ~Update references to the old key string value in the WebformElement with the new key module approach~
- ~An update hook to enable the key module for existing module users~
- ~An update hook to move the old key string value into a key config entity~

<img width="705" alt="Screenshot 2020-05-14 at 21 08 16" src="https://user-images.githubusercontent.com/4610533/81981162-d33b6f00-9627-11ea-8324-dbca6204abde.png">

<img width="854" alt="Screenshot 2020-05-14 at 21 16 28" src="https://user-images.githubusercontent.com/4610533/81981458-3927f680-9628-11ea-96ea-763265d3e576.png">
