### PR TITLE
PCA Webform improvements

### DIFF
--- a/modules/pca_webform/src/Element/WebformAddressLoqate.php
+++ b/modules/pca_webform/src/Element/WebformAddressLoqate.php
@@ -9,6 +9,9 @@ use Drupal\webform\Element\WebformCompositeBase;
  * Provides a Webform element for an address element.
  *
  * @FormElement("webform_address_loqate")
+ *
+ * @deprecated in Loqate 2.1.0 and will be removed in Loqate 3.0.0. Use
+ *   \Drupal\loqate\Element\PcaAddress instead.
  */
 class WebformAddressLoqate extends WebformCompositeBase {
 

--- a/modules/pca_webform/src/Plugin/WebformElement/LoqatePcaAddress.php
+++ b/modules/pca_webform/src/Plugin/WebformElement/LoqatePcaAddress.php
@@ -28,6 +28,13 @@ class LoqatePcaAddress extends WebformCompositeBase {
   /**
    * {@inheritdoc}
    */
+  public function getPluginLabel() {
+    return \Drupal::moduleHandler()->moduleExists('pca_address') ? $this->t('Basic PCA address') : parent::getPluginLabel();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getCompositeElements() {
     return [];
   }

--- a/modules/pca_webform/src/Plugin/WebformElement/LoqatePcaAddress.php
+++ b/modules/pca_webform/src/Plugin/WebformElement/LoqatePcaAddress.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\pca_webform\Plugin\WebformElement;
+
+use Drupal\loqate\PcaAddressFieldMapping\PcaAddressElement;
+use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
+
+/**
+ * Provides a 'PCA address' element.
+ *
+ * @WebformElement(
+ *   id = "pca_address",
+ *   label = @Translation("PCA address"),
+ *   description = @Translation("Provides a form element to collect address information (street, city, state, zip)."),
+ *   category = @Translation("Composite elements"),
+ *   multiline = TRUE,
+ *   composite = TRUE,
+ *   states_wrapper = TRUE,
+ *   dependencies = {
+ *     "loqate",
+ *   }
+ * )
+ *
+ * @see \Drupal\loqate\Element\PcaAddress
+ */
+class LoqatePcaAddress extends WebformCompositeBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCompositeElements() {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @see \Drupal\loqate\Plugin\Field\FieldType\LoqatePcaAddressItem::schema
+   */
+  public function initializeCompositeElements(array &$element) {
+    $element['#webform_composite_elements'] = [
+      PcaAddressElement::LINE1 => [
+        '#title' => $this->t('Address Line 1'),
+        '#type' => 'textfield',
+        '#maxlength' => 255,
+      ],
+      PcaAddressElement::LINE2 => [
+        '#title' => $this->t('Address Line 2'),
+        '#type' => 'textfield',
+        '#maxlength' => 255,
+      ],
+      PcaAddressElement::LOCALITY => [
+        '#title' => $this->t('City/Town'),
+        '#type' => 'textfield',
+        '#maxlength' => 255,
+      ],
+      PcaAddressElement::ADMINISTRATIVE_AREA => [
+        '#title' => $this->t('State/Province'),
+        '#type' => 'textfield',
+        '#maxlength' => 255,
+      ],
+      PcaAddressElement::POSTAL_CODE => [
+        '#title' => $this->t('ZIP/Postal Code'),
+        '#type' => 'textfield',
+        '#maxlength' => 255,
+      ],
+      PcaAddressElement::COUNTRY_CODE => [
+        '#title' => $this->t('Country'),
+        '#type' => 'textfield',
+        '#maxlength' => 2,
+      ],
+    ];
+  }
+
+}

--- a/modules/pca_webform/src/Plugin/WebformElement/WebformAddressLoqate.php
+++ b/modules/pca_webform/src/Plugin/WebformElement/WebformAddressLoqate.php
@@ -11,13 +11,16 @@ use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
  *
  * @WebformElement(
  *   id = "webform_address_loqate",
- *   label = @Translation("PCA address"),
+ *   label = @Translation("PCA address (deprecated)"),
  *   description = @Translation("Loqate API provides a form element to collect address information (street, city, state, zip)."),
  *   category = @Translation("Composite elements"),
  *   multiline = TRUE,
  *   composite = TRUE,
  *   states_wrapper = TRUE,
  * )
+ *
+ * @deprecated in Loqate 2.1.0 and will be removed in Loqate 3.0.0. Use
+ *   \Drupal\pca_webform\Plugin\WebformElement\LoqatePcaAddress instead.
  */
 class WebformAddressLoqate extends WebformCompositeBase {
 
@@ -25,7 +28,7 @@ class WebformAddressLoqate extends WebformCompositeBase {
    * {@inheritdoc}
    */
   public function getPluginLabel() {
-    return \Drupal::moduleHandler()->moduleExists('pca_address') ? $this->t('Basic PCA address') : parent::getPluginLabel();
+    return \Drupal::moduleHandler()->moduleExists('pca_address') ? $this->t('Basic PCA address (deprecated)') : parent::getPluginLabel();
   }
 
   /**

--- a/modules/pca_webform/src/Plugin/WebformElement/WebformAddressLoqate.php
+++ b/modules/pca_webform/src/Plugin/WebformElement/WebformAddressLoqate.php
@@ -20,7 +20,7 @@ use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
  * )
  *
  * @deprecated in Loqate 2.1.0 and will be removed in Loqate 3.0.0. Use
- *   \Drupal\pca_webform\Plugin\WebformElement\LoqatePcaAddress instead.
+ *   \Drupal\loqate\Plugin\WebformElement\LoqatePcaAddress instead.
  */
 class WebformAddressLoqate extends WebformCompositeBase {
 

--- a/src/Plugin/WebformElement/LoqatePcaAddress.php
+++ b/src/Plugin/WebformElement/LoqatePcaAddress.php
@@ -80,8 +80,14 @@ class LoqatePcaAddress extends WebformCompositeBase {
   /**
    * {@inheritdoc}
    */
-  public function getDefaultProperties() {
-    return [] + parent::getDefaultProperties();
+  protected function defineDefaultProperties() {
+    return [
+      'pca_fields' => [],
+      'pca_options' => [],
+      'show_address_fields' => FALSE,
+      'allow_manual_input' => TRUE,
+      'loqate_api_key' => NULL,
+    ] + parent::defineDefaultProperties();
   }
 
   /**
@@ -89,6 +95,28 @@ class LoqatePcaAddress extends WebformCompositeBase {
    */
   public function form(array $form, FormStateInterface $form_state) {
     $form = parent::form($form, $form_state);
+
+    $form['pca_address'] = [
+      '#type' => 'details',
+      '#title' => $this->t('PCA address'),
+      '#open' => TRUE,
+    ];
+
+    $form['pca_address']['show_address_fields'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show address fields'),
+    ];
+
+    $form['pca_address']['allow_manual_input'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Allow manual input'),
+    ];
+
+    $form['pca_address']['loqate_api_key'] = [
+      '#type' => 'key_select',
+      '#title' => $this->t('Loqate API key'),
+    ];
+
     return $form;
   }
 

--- a/src/Plugin/WebformElement/LoqatePcaAddress.php
+++ b/src/Plugin/WebformElement/LoqatePcaAddress.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Drupal\pca_webform\Plugin\WebformElement;
+namespace Drupal\loqate\Plugin\WebformElement;
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\loqate\PcaAddressFieldMapping\PcaAddressElement;
 use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
 
@@ -16,12 +17,9 @@ use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
  *   multiline = TRUE,
  *   composite = TRUE,
  *   states_wrapper = TRUE,
- *   dependencies = {
- *     "loqate",
- *   }
  * )
  *
- * @see \Drupal\loqate\Element\PcaAddress
+ * @see \Drupal\loqate\Element\LoqatePcaAddress
  */
 class LoqatePcaAddress extends WebformCompositeBase {
 
@@ -77,6 +75,21 @@ class LoqatePcaAddress extends WebformCompositeBase {
         '#maxlength' => 2,
       ],
     ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefaultProperties() {
+    return [] + parent::getDefaultProperties();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+    return $form;
   }
 
 }


### PR DESCRIPTION
Using the new FormElement in the base `loqate` module for Webform support going forward as it shares the logic across all 3 modules.

Also deprecating `webform_address_loqate` for removal in `v3.0.0` of the module.

<img width="529" alt="Screenshot 2020-05-27 at 22 22 18" src="https://user-images.githubusercontent.com/4610533/83073588-98462c00-a068-11ea-8f78-6771857b5fc4.png">
